### PR TITLE
Fix Windows mixed-slash imports in generated routes.nim

### DIFF
--- a/src/crown/generator.nim
+++ b/src/crown/generator.nim
@@ -7,6 +7,13 @@ type
     methods: seq[tuple[name: string, layout: string]]
     importName: string
 
+proc normalizeModulePath*(path: string): string =
+  ## Convert filesystem separators to Nim module separators.
+  path.replace("\\", "/").replace(".nim", "")
+
+proc makeImportAlias*(modulePath: string): string =
+  modulePath.replace("\\", "_").replace("/", "_").replace("-", "_")
+
 proc writeFileIfChanged(path, content: string) =
   if fileExists(path) and readFile(path) == content:
     return
@@ -65,12 +72,11 @@ proc generateRoutesCode*(appDir: string, isDev: bool = false): string =
       let content = readFile(path)
       let methods = detectMethods(content)
       if methods.len > 0:
-        let relPath = path.relativePath("src/")
-        let importName = relPath.replace("/", "_").replace(".nim", "").replace(
-            "-", "_")
+        let relPath = normalizeModulePath(path.relativePath("src"))
+        let importName = makeImportAlias(relPath)
 
         let entry = RouteEntry(
-          filePath: relPath.replace(".nim", ""),
+          filePath: relPath,
           urlPath: resolveUrlPath(appDir, path),
           methods: methods,
           importName: importName
@@ -91,10 +97,10 @@ proc generateRoutesCode*(appDir: string, isDev: bool = false): string =
   if dirExists(layoutDir):
     for path in walkDirRec(layoutDir):
       if path.endsWith(".nim"):
-        let relPath = path.relativePath("src/")
+        let relPath = normalizeModulePath(path.relativePath("src"))
         let layoutImportName = "crown_layout_" & path.extractFilename().replace(
             ".nim", "")
-        let stmt = &"import ../src/{relPath.replace(\".nim\", \"\")} as {layoutImportName}\n"
+        let stmt = &"import ../src/{relPath} as {layoutImportName}\n"
         if not layoutImports.contains(stmt):
           code &= stmt
           layoutImports.incl(stmt)

--- a/tests/tgenerator.nim
+++ b/tests/tgenerator.nim
@@ -1,4 +1,5 @@
 import std/unittest
+import std/sequtils
 import crown/generator
 
 suite "Generator tests":
@@ -13,9 +14,10 @@ suite "Generator tests":
       return htmlResponse fmt"saved"
     """
     let methods = detectMethods(sampleContent)
-    check "page" in methods
-    check "post" in methods
-    check "get" notin methods
+    let methodNames = methods.mapIt(it.name)
+    check "page" in methodNames
+    check "post" in methodNames
+    check "get" notin methodNames
 
   test "resolveUrlPath properly resolves nested directory structures":
     # Mocks app structure
@@ -24,3 +26,10 @@ suite "Generator tests":
     check resolveUrlPath(root, "/example/src/app/page.nim") == "/"
     check resolveUrlPath(root, "/example/src/app/editor/page.nim") == "/editor"
     check resolveUrlPath(root, "/example/src/app/api/save.nim") == "/api/save"
+
+  test "normalizes windows module paths for imports and aliases":
+    check normalizeModulePath(r"app\page.nim") == "app/page"
+    check normalizeModulePath(r"app\admin\index.nim") == "app/admin/index"
+    check makeImportAlias(r"app\page") == "app_page"
+    check makeImportAlias("app/page") == "app_page"
+    check makeImportAlias("app/admin-user/page") == "app_admin_user_page"


### PR DESCRIPTION
## Summary
- normalize generated module paths to forward-slash format before writing import statements
- use the normalized module path consistently for both import target and alias generation
- add generator tests for Windows-style backslash paths

## Validation
- nim c --path:src -r tests/tgenerator.nim
- nim c --path:src src/crown.nim

Closes #2